### PR TITLE
Fix simulation helper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.2.4
+Version: 0.2.5
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -153,7 +153,7 @@ spim_simulate_args <- function(grid, vars, base, ignore, regions, multistrain) {
 ##'
 ##' @export
 spim_simulate_local <- function(args, combined) {
-  lapply(seq_along(args), spim_simulate)
+  lapply(seq_along(args), spim_simulate, args, combined)
 }
 
 ##' Run simulations with rrq workers
@@ -169,7 +169,7 @@ spim_simulate_local <- function(args, combined) {
 ##'
 ##' @export
 spim_simulate_rrq <- function(args, combined, rrq) {
-  rrq$lapply(seq_along(args), spim_simulate)
+  rrq$lapply(seq_along(args), spim_simulate, args, combined)
 }
 
 

--- a/R/simulate_tools.R
+++ b/R/simulate_tools.R
@@ -1,4 +1,4 @@
-spim_simulate <- function(i) {
+spim_simulate <- function(i, args, combined) {
   el <- args[[i]]
   message(sprintf("-----\nRunning scenario %d / %d", i, length(args)))
   time <- system.time(


### PR DESCRIPTION
Fixes scoping error introduced in #19 

Not totally ideal as we might not want to export all of `args` to rrq. Something we should think about tomorrow @RaphaelS1 