### PR TITLE
switch to linelist chr/comm deaths in full_data for last 45 days

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.2.12
+Version: 0.2.13
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/combined.R
+++ b/R/combined.R
@@ -177,7 +177,7 @@ combined_aggregate_data <- function(data) {
     ret$deaths <- pmax(ret$deaths,
                        rowSums(ret[, death_nms], na.rm = TRUE),
                        na.rm = TRUE)
-    ret[-seq_len(nrow(ret) - 5), ] <- NA
+    ret[-seq_len(nrow(ret) - 4), death_nms] <- NA
     data_frame(ret, x[, date_names])
   }
 

--- a/R/data.R
+++ b/R/data.R
@@ -166,8 +166,18 @@ spim_data_rtm <- function(date, region, model_type, data, full_data,
         data$date >= date_death_change ~ NA_integer_
       )
     } else {
-      data$deaths_carehomes <- data$ons_death_carehome
-      data$deaths_comm <- data$ons_death_noncarehome
+      ## due to ONS data being lagged, in the full_data version (not used in
+      ## fitting) we will use death linelist data for recent care home and
+      ## community deaths
+      date_death_change <- as.Date(date) - 45
+      data$deaths_carehomes <- dplyr::case_when(
+        data$date < date_death_change ~ as.integer(data$ons_death_carehome),
+        data$date >= date_death_change ~ as.integer(data$death_chr)
+      )
+      data$deaths_comm <- dplyr::case_when(
+        data$date < date_death_change ~ as.integer(data$ons_death_noncarehome),
+        data$date >= date_death_change ~ as.integer(data$death_comm)
+      )
     }
   }
 


### PR DESCRIPTION
Switches to linelist deaths for the last 45 days in the full_data (i.e. not fitted) version for care home and community deaths. Hopefully will give a better representation of recent total deaths data in plotting as less lagged than ONS.

Additionally a minor fix in the combined_aggregate_data function - which was setting all aggregated data in the last 5 days to NA. However, it is only the deaths data streams that need to be set to NA, and only for the last 4 days (as happens in the fitting).