### PR TITLE
zero NAs in pillar2 data we're fitting to and trim age-specific pilla…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.5.2
+Version: 0.5.3
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/data.R
+++ b/R/data.R
@@ -530,6 +530,8 @@ spim_lancelot_data_rtm <- function(date, region, model_type, data, full_data,
 
   data$pillar2_cases <- data$pillar2_positives
   data$pillar2_cases_over25 <- data$pillar2_positives_over25
+  data[, paste0("pillar2_cases_", pillar2_age_bands)] <-
+    data[, paste0("pillar2_positives_", pillar2_age_bands)]
 
   ## Use symp PCR only for cases where available
   if (!all(is.na(data$pillar2_positives_symp_pcr_only))) {

--- a/R/data.R
+++ b/R/data.R
@@ -618,7 +618,8 @@ spim_lancelot_data_rtm <- function(date, region, model_type, data, full_data,
   # after that date turn NAs to zeroes for columns where data is available
   for (i in cols_pillar2) {
     if (!all(is.na(data[, i]))) {
-      data[which(data$date >= "2020-06-18"), i] <- 0
+      data[which(data$date >= "2020-06-18"), i][
+        is.na(data[which(data$date >= "2020-06-18"), i])] <- 0
     }
   }
 

--- a/R/data.R
+++ b/R/data.R
@@ -611,15 +611,15 @@ spim_lancelot_data_rtm <- function(date, region, model_type, data, full_data,
                     paste0("pillar2_cases_",
                            c("over25", pillar2_age_bands)))
 
-  # ignore pillar 2 testing before 2020-06-18
-  data[which(data$date < "2020-06-18"), cols_pillar2] <- NA_integer_
-  # after that date turn NAs to zeroes for columns where data is available
+  # Turn NAs to zeroes for pillar 2 columns where data is available
   for (i in cols_pillar2) {
     if (!all(is.na(data[, i]))) {
-      data[which(data$date >= "2020-06-18"), i][
-        is.na(data[which(data$date >= "2020-06-18"), i])] <- 0
+      data[which(is.na(data[, i])), i] <- 0
     }
   }
+
+  # ignore pillar 2 testing before 2020-06-18
+  data[which(data$date < "2020-06-18"), cols_pillar2] <- NA_integer_
 
   last_week <- seq(to = nrow(data), length.out = 7)
   ## Remove last week admissions for Wales (due to backfill)

--- a/R/data.R
+++ b/R/data.R
@@ -58,9 +58,6 @@ spim_data_single <- function(date, region, model_type, rtm, serology,
                              trim_deaths, trim_pillar2, full_data,
                              fit_to_variants, sircovid_model) {
 
-  pillar2_over25_age_bands <- c("25_49", "50_64", "65_79", "80_plus")
-  pillar2_age_bands <- c("under15", "15_24", pillar2_over25_age_bands)
-
   ## TODO: verify that rtm has consecutive days
   if (sircovid_model == "carehomes") {
     rtm <- spim_carehomes_data_rtm(date, region, model_type, rtm, full_data,
@@ -68,8 +65,7 @@ spim_data_single <- function(date, region, model_type, rtm, serology,
   } else if (sircovid_model == "lancelot") {
     ## TODO: verify that rtm has consecutive days
     rtm <- spim_lancelot_data_rtm(date, region, model_type, rtm, full_data,
-                                  fit_to_variants, pillar2_over25_age_bands,
-                                  pillar2_age_bands)
+                                  fit_to_variants)
   }
   serology <- spim_data_serology(date, region, serology)
 
@@ -388,8 +384,10 @@ spim_carehomes_data_rtm <- function(date, region, model_type, data, full_data,
 
 ##' @importFrom dplyr %>%
 spim_lancelot_data_rtm <- function(date, region, model_type, data, full_data,
-                                   fit_to_variants, pillar2_over25_age_bands,
-                                   pillar2_age_bands) {
+                                   fit_to_variants) {
+
+  pillar2_over25_age_bands <- c("25_49", "50_64", "65_79", "80_plus")
+  pillar2_age_bands <- c("under15", "15_24", pillar2_over25_age_bands)
 
   vars <- c("phe_patients", "phe_occupied_mv_beds",  "icu", "general",
             "admitted", "new", "phe_admissions", "all_admission",

--- a/R/data.R
+++ b/R/data.R
@@ -103,12 +103,7 @@ spim_data_single <- function(date, region, model_type, rtm, serology,
   ## are too likely to be back-filled to be reliable
   ## TODO: this works only for Lancelot - carehomes will be soon removed
   i <- seq(to = nrow(data), length.out = trim_pillar2)
-  cols_pillar2 <- c("pillar2_tot", "pillar2_pos", "pillar2_cases",
-                    "pillar2_over25_tot", "pillar2_over25_pos",
-                    "pillar2_over25_cases",
-                    paste0("pillar2_", pillar2_age_bands, "_tot"),
-                    paste0("pillar2_", pillar2_age_bands, "_pos"),
-                    paste0("pillar2_", pillar2_age_bands, "_cases"))
+  cols_pillar2 <- grep("pillar2", colnames(data), value = TRUE)
   data[i, cols_pillar2] <- NA_integer_
 
   data


### PR DESCRIPTION
In this PR:

1. NAs in pillar 2 data we're actually fitting to are zeroed
2. Add age-specific pillar 2 columns to trimming 
3. Move age-bands one level up from function `spim_lancelot_data_rtm` to `spim_data_single`