### PR TITLE
Refactoring simulation task

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.5.8
+Version: 0.5.9
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.5.7
+Version: 0.5.8
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/simulate_plots.R
+++ b/R/simulate_plots.R
@@ -256,12 +256,14 @@ spim_plot_check_rt <- function(summary_state, combined_state, dates) {
 
   summary_state %>%
 
+    ## TODO: for SPI-M we report 90% CI, hence 5% and 95% here but
+    ## default below; shall we change default?
     ggplot(aes(x = date, y = `50%`, colour = scenario)) +
     theme_bw() +
     theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
     geom_ribbon(alpha = 0.3,
-                aes(ymin = `2.5%`,
-                    ymax = `97.5%`,
+                aes(ymin = `5%`,
+                    ymax = `95%`,
                     fill = scenario)) +
     geom_line() +
 
@@ -304,12 +306,14 @@ spim_plot_check_state <- function(summary_state, combined_state) {
     tidyr::pivot_wider(names_from = quantile)
 
   summary_state %>%
+    ## TODO: for SPI-M we report 90% CI, hence 5% and 95% here but
+    ## default below; shall we change default?
     ggplot(aes(x = date)) +
     theme_bw() +
     theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
     geom_ribbon(alpha = 0.3,
-                aes(ymin = `2.5%`,
-                    ymax = `97.5%`,
+                aes(ymin = `5%`,
+                    ymax = `95%`,
                     fill = scenario)) +
 
     geom_line(aes(y = `50%`, color = scenario)) +

--- a/R/simulate_plots.R
+++ b/R/simulate_plots.R
@@ -293,14 +293,14 @@ spim_plot_check_state <- function(summary_state, combined_state) {
     dplyr::mutate(scenario = as.factor(scenario),
                   analysis = as.factor(analysis)) %>%
     dplyr::filter(state %in% c("diagnoses_admitted_inc",
-                              "deaths_inc", "deaths_hosp_inc",
+                              "deaths_inc", "infections_inc",
                               "hosp"),
                   group == "all") %>%
     tidyr::pivot_wider(names_from = quantile)
 
   combined_state <- dplyr::filter(combined_state, region == "england") %>%
     dplyr::filter(state %in% c("diagnoses_admitted_inc",
-                              "deaths_inc", "deaths_hosp_inc",
+                              "deaths_inc", "infections_inc",
                               "hosp"),
                   group == "all") %>%
     tidyr::pivot_wider(names_from = quantile)

--- a/R/simulate_plots.R
+++ b/R/simulate_plots.R
@@ -254,10 +254,9 @@ spim_plot_check_rt <- function(summary_state, combined_state, dates) {
                     state %in% c("Rt_general_both", "eff_Rt_general_both")) %>%
       tidyr::pivot_wider(names_from = quantile)
 
+  # TODO:: for SPI-M we report 90% CI, hence 5% and 95% here but
+  # default below; shall we change default?
   summary_state %>%
-
-    ## TODO: for SPI-M we report 90% CI, hence 5% and 95% here but
-    ## default below; shall we change default?
     ggplot(aes(x = date, y = `50%`, colour = scenario)) +
     theme_bw() +
     theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
@@ -305,9 +304,9 @@ spim_plot_check_state <- function(summary_state, combined_state) {
                   group == "all") %>%
     tidyr::pivot_wider(names_from = quantile)
 
+  # TODO:: for SPI-M we report 90% CI, hence 5% and 95% here but
+  # default below; shall we change default?
   summary_state %>%
-    ## TODO: for SPI-M we report 90% CI, hence 5% and 95% here but
-    ## default below; shall we change default?
     ggplot(aes(x = date)) +
     theme_bw() +
     theme(axis.text.x = element_text(angle = 45, hjust = 1)) +

--- a/R/simulate_tools.R
+++ b/R/simulate_tools.R
@@ -399,8 +399,6 @@ spim_simulate_reset_cumulative_states <- function(res, state_names) {
 ##' removed
 ##' @param output_region Character vector of regions to output, defaults to
 ##' `combined_region`
-##' @param output_region_only Logical, indicating whether to output results
-##'  only for `output_region` as opposed to `regions`
 ##' @param simulation_start_date If not `NULL` then removes all data before
 ##'  the given date.
 ##' @export
@@ -409,9 +407,12 @@ spim_simulate_process_output <- function(obj, combined_region, regions,
                                          reset_states = FALSE,
                                          rm.rtUK = FALSE,
                                          output_region = NULL,
-                                         output_region_only = FALSE,
                                          simulation_start_date = NULL) {
 
+  # IF output_region is NULL, outputs for all regions and national aggregation
+  # will be processed. Else, only the output_region's results will (e.g.
+  # aggregation to the England or UK level)
+  output_region_only <- !is.null(output_region)
   output_region <- output_region %||% combined_region
   ret <- spim_simulate_combine_trajectories(obj, combined_region, regions,
                                             rm.rtUK)

--- a/R/simulate_tools.R
+++ b/R/simulate_tools.R
@@ -293,18 +293,18 @@ spim_simulate_remove_dates_to <- function(obj, date) {
   if (min(obj$date) == sircovid::sircovid_date(date)) {
     # For most simulations, we include state variables from the date of the
     # simulation start onward
-    date <- date
+    remove_to_date <- date
 
   } else if (min(obj$date) < sircovid::sircovid_date(date)) {
     # e.g. for an MTP that is run off fits from Friday, we would remove
     # state variables prior to the Monday when submission is due
-    date <- date - 1
+    remove_to_date <- date - 1
 
   } else {
     stop(message("Error, obj$date cannot be greater than date"))
   }
 
-  id0 <- seq(which(sircovid::sircovid_date_as_date(obj$date) == date))
+  id0 <- seq(which(sircovid::sircovid_date_as_date(obj$date) == remove_to_date))
   obj$date <- obj$date[-id0]
   obj$state <- obj$state[, , , -id0, drop = FALSE]
   obj$state_by_age <- lapply(obj$state_by_age, function(x)

--- a/R/simulate_tools.R
+++ b/R/simulate_tools.R
@@ -291,9 +291,15 @@ spim_simulate_remove_dates_to <- function(obj, date) {
   }
 
   if (min(obj$date) == sircovid::sircovid_date(date)) {
+    # For most simulations, we include state variables from the date of the
+    # simulation start onward
     date <- date
+
   } else if (min(obj$date) < sircovid::sircovid_date(date)) {
+    # e.g. for an MTP that is run off fits from Friday, we would remove
+    # state variables prior to the Monday when submission is due
     date <- date - 1
+
   } else {
     stop(message("Error, obj$date cannot be greater than date"))
   }

--- a/man/spim_simulate_process_output.Rd
+++ b/man/spim_simulate_process_output.Rd
@@ -12,6 +12,7 @@ spim_simulate_process_output(
   reset_states = FALSE,
   rm.rtUK = FALSE,
   output_region = NULL,
+  output_region_only = FALSE,
   simulation_start_date = NULL
 )
 }
@@ -32,6 +33,9 @@ removed}
 
 \item{output_region}{Character vector of regions to output, defaults to
 \code{combined_region}}
+
+\item{output_region_only}{Logical, indicating whether to output results
+only for \code{output_region} as opposed to \code{regions}}
 
 \item{simulation_start_date}{If not \code{NULL} then removes all data before
 the given date.}

--- a/man/spim_simulate_process_output.Rd
+++ b/man/spim_simulate_process_output.Rd
@@ -12,7 +12,6 @@ spim_simulate_process_output(
   reset_states = FALSE,
   rm.rtUK = FALSE,
   output_region = NULL,
-  output_region_only = FALSE,
   simulation_start_date = NULL
 )
 }
@@ -33,9 +32,6 @@ removed}
 
 \item{output_region}{Character vector of regions to output, defaults to
 \code{combined_region}}
-
-\item{output_region_only}{Logical, indicating whether to output results
-only for \code{output_region} as opposed to \code{regions}}
 
 \item{simulation_start_date}{If not \code{NULL} then removes all data before
 the given date.}


### PR DESCRIPTION
This PR fixes issue 128. For culling outputs from simulation task:
- `date - 1` is used when the date of simulation start is after the first (min) date of simulated trajectories (e.g. when running MTPs off data from a Friday)
- Else input argument `date` will be used

Other refactoring changes introduced are:
- Function `spim_simulate_process_output` takes additional logical parameter `output_region_only`. A lot of repetition of code was being used across simulation tasks to process immediate simulation results! This exported function should be the primary one to call for this purpose. If set to TRUE, only outputs for the national level are produced (e.g. England) as in the case of a CO commission. Else all regions and national aggregation are outputted (e.g. for MTPs).
- Diagnostic plotting tasks `spim_plot_check_rt` and `spim_plot_check_state` have different limits for CI ribbon around median trajectory. This is a TODO issue really; we should decide whether to change the default quantiles in `spim_simulate_create_summary`. For SPI-M a vector of 90% CI by 5% is required, but for other downstream tasks we use only 2.5%, 50% and 97.5%

Fixes #128 