### PR TITLE
use schools schedule instead of CSV path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.5.9
+Version: 0.5.10
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -1778,8 +1778,8 @@ spim_rejuvenatoR <- function(summary, dates, scenarios = NULL, analyses = NULL,
 #' npi (name of corresponding npi in npi_key), nation
 #'
 #' @export
-spim_create_rt_scenario <- function(path, region, scenario, schedule) {
-  sched <- read.csv(path) %>%
+spim_create_rt_scenario <- function(sched, region, scenario, schedule) {
+  sched <- sched %>%
     dplyr::filter(nation %in% region) %>%
     dplyr::mutate(date = as.Date(sprintf("%s-%s-%s", year, month, day))) %>%
     dplyr::arrange(date)

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -1769,7 +1769,7 @@ spim_rejuvenatoR <- function(summary, dates, scenarios = NULL, analyses = NULL,
 #' Create a scenario for Rt schedule
 #'
 #' @title Create Rt schedule scenario
-#' @param path Path to a csv with school closure schedule. Expect
+#' @param sched A data frame with school closure schedule. Expect
 #' columns: nation; year; month; day; schools ('open' if open on that day
 #' otherwise 'closed')
 #' @param region Region to filter csv by

--- a/man/spim_create_rt_scenario.Rd
+++ b/man/spim_create_rt_scenario.Rd
@@ -4,10 +4,10 @@
 \alias{spim_create_rt_scenario}
 \title{Create Rt schedule scenario}
 \usage{
-spim_create_rt_scenario(path, region, scenario, schedule)
+spim_create_rt_scenario(sched, region, scenario, schedule)
 }
 \arguments{
-\item{path}{Path to a csv with school closure schedule. Expect
+\item{sched}{A data frame with school closure schedule. Expect
 columns: nation; year; month; day; schools ('open' if open on that day
 otherwise 'closed')}
 


### PR DESCRIPTION
This PR is complementary to ncov PR https://github.com/ncov-ic/ncov-outputs/pull/1879

Helper function `spim_create_rt_scenario` uses actual data frame of schools schedule, rather than a character string pointing to the location of the file