### PR TITLE
Allow serial_interval_scale to be modified

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.5.18
+Version: 0.5.19
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/new_simulation.R
+++ b/R/new_simulation.R
@@ -267,6 +267,7 @@ validate_simulate_parameters <- function(control, require_beta_step) {
                           "booster_daily_doses",
                           "strain_vaccine_efficacy",
                           "vaccine_uptake",
+                          "serial_interval_scale",
                           "strain_cross_immunity",
                           "strain_transmission",
                           "strain_seed_date",


### PR DESCRIPTION
This is a tiny PR that allows `serial_interval_scale` to be modified.  At present this is trivial; we allow it to be included in the list of changeable things.

Once more of the simulation code moves into this package we'll include the actual modification code that is required to take advantage of this; currently that looks like 

```
  update$rel_gamma_E <-
    1 / sircovid:::mirror_strain(pars_simulation$serial_interval_scale)
```

but this will become a set of sircovid/spimalot functions.

Note that I have not used the `strain_` prefix because everywhere else this is used to refer to things that only affect the second strain (I think, there might be some exceptions still) and `serial_interval_scale` can be used to change either the serial interval of either strain.
