### PR TITLE
Vaccine epochs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.5.29
+Version: 0.5.30
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.5.30
+Version: 0.5.31
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -257,7 +257,7 @@ calculate_lancelot_Rt <- function(samples, weight_Rt) {
       R_nms <- get_names("R",
                          list(S = n_strains, V = n_vacc_classes),
                          suffix)
-      R1 <- R[, , dates1, drop = FALSE]
+      R1 <- R[R_nms, , dates1, drop = FALSE]
       prob_strain1 <- prob_strain[, , dates1, drop = FALSE]
     }
 

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -241,15 +241,22 @@ calculate_lancelot_Rt <- function(samples, weight_Rt) {
       next
     }
 
-    step1 <- step[dates1]
-    S1 <- S[, , dates1, drop = FALSE]
-
     n_strains <- pars[[i]][[1]]$n_strains
+    n_vacc_classes <- pars[[i]][[1]]$n_vacc_classes
+
+    suffix <- paste0("_", c(sircovid:::sircovid_age_bins()$start, "CHW", "CHR"))
+    S_nms <- get_names("S", list(n_vacc_classes), suffix)
+
+    step1 <- step[dates1]
+    S1 <- S[S_nms, , dates1, drop = FALSE]
 
     if (n_strains == 1) {
       R1 <- NULL
       prob_strain1 <- NULL
     } else {
+      R_nms <- get_names("R",
+                         list(S = n_strains, V = n_vacc_classes),
+                         suffix)
       R1 <- R[, , dates1, drop = FALSE]
       prob_strain1 <- prob_strain[, , dates1, drop = FALSE]
     }
@@ -814,4 +821,27 @@ calculate_cases <- function(samples) {
     abind1(samples$trajectories$state, cases)
 
   samples
+}
+
+## adapted from sircovid:::calculate_index
+get_names <- function(state_name, suffix_list, suffix0 = NULL) {
+  if (is.null(suffix0)) {
+    suffixes <- list()
+  } else {
+    suffixes <- list(suffix0)
+  }
+  for (i in seq_along(suffix_list)) {
+    nm <- names(suffix_list)[[i]]
+    if (length(nm) == 0) {
+      nm <- ""
+    }
+    suffixes <- c(suffixes,
+                  list(c("", sprintf("_%s%s", nm,
+                                     seq_len(suffix_list[[i]] - 1L)))))
+  }
+  suffixes <- expand.grid(suffixes)
+  nms <- apply(suffixes, 1,
+               function(x) sprintf("%s%s",
+                                   state_name, paste0(x, collapse = "")))
+  nms
 }

--- a/R/vaccination.R
+++ b/R/vaccination.R
@@ -20,6 +20,13 @@
 ##' @export
 spim_vaccination_data <- function(date, region, uptake, days_to_effect, data) {
 
+  ## Vaccination started 2020-12-08. There should be no doses before this
+  ## so we remove dates before this
+  data <- data[data$date >= "2020-12-08", ]
+
+  ## Boosters started 2021-09-15, so ignore any third doses before this date
+  data$third_dose[data$date < "2021-09-15"] <- 0
+
   ## Remove any data after date parameter
   data <- data[data$date <= date, ]
 


### PR DESCRIPTION
This PR sets us up better for vaccine epochs - part of the issue is the changing dimensionality of S and R compartments as we increase vaccine classes, this fixes things so the Rt calculation works flexibly around that. (We will likely move some of this stuff into sircovid after Christmas).

Also, due to fixing vaccine epochs at certain dates, we filter out any doses before vaccination officially began (there shouldn't actually be any though), and any 3rd doses before the booster programme officially began (probably some for England only but relatively small).