### PR TITLE
Proper control over workers for deterministic model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.5.31
+Version: 0.5.32
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/control.R
+++ b/R/control.R
@@ -82,7 +82,9 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
     ## Increase the number of workers because each will be running
     ##   separately. If running on a laptop this probably does not want
     ##   increasing
-    pmcmc$n_workers <- min(pmcmc$n_chains, pmcmc$n_threads_total)
+    if (workers) {
+      pmcmc$n_workers <- min(pmcmc$n_chains, pmcmc$n_threads_total)
+    }
   }
 
   particle_filter <- list(n_particles = n_particles,

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -82,3 +82,17 @@ test_that("spim control short run is shorter", {
   expect_equal(ctl_short$particle_filter$n_particles, 10)
   expect_equal(ctl_long$particle_filter$n_particles, 192)
 })
+
+
+test_that("Allow disabling workers for deterministic fit", {
+  suppressMessages(
+    control1 <- spimalot::spim_control(
+      TRUE, 4, TRUE, n_mcmc = 100,
+      burnin = 5, forecast_days = 0, workers = TRUE))
+  expect_equal(control1$pmcmc$n_workers, 4)
+  suppressMessages(
+    control2 <- spimalot::spim_control(
+      TRUE, 4, TRUE, n_mcmc = 100,
+      burnin = 5, forecast_days = 0, workers = FALSE))
+  expect_equal(control2$pmcmc$n_workers, 1)
+})

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -86,13 +86,17 @@ test_that("spim control short run is shorter", {
 
 test_that("Allow disabling workers for deterministic fit", {
   suppressMessages(
-    control1 <- spimalot::spim_control(
-      TRUE, 4, TRUE, n_mcmc = 100,
-      burnin = 5, forecast_days = 0, workers = TRUE))
-  expect_equal(control1$pmcmc$n_workers, 4)
+    withr::with_envvar(c(MC_CORES = 2), {
+      control1 <- spimalot::spim_control(
+        TRUE, 2, TRUE, n_mcmc = 100,
+        burnin = 5, forecast_days = 0, workers = TRUE)
+    }))
+  expect_equal(control1$pmcmc$n_workers, 2)
   suppressMessages(
+    withr::with_envvar(c(MC_CORES = 2), {
     control2 <- spimalot::spim_control(
       TRUE, 4, TRUE, n_mcmc = 100,
-      burnin = 5, forecast_days = 0, workers = FALSE))
+      burnin = 5, forecast_days = 0, workers = FALSE)
+    }))
   expect_equal(control2$pmcmc$n_workers, 1)
 })


### PR DESCRIPTION
Previously `workers = FALSE` was not actually disabling the workers when `deterministic = TRUE`. Small fix + test to correct this