### PR TITLE
Better control when using multiregion/deterministic fits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,7 +85,7 @@ Suggests:
     withr
 Remotes:
     mrc-ide/dust,
-    mrc-ide/mcstate@i179-chains-path,
+    mrc-ide/mcstate,
     mrc-ide/rrq,
     mrc-ide/sircovid
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.6.4
+Version: 0.6.5
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,7 @@ Imports:
     khroma,
     lubridate,
     matrixStats,
-    mcstate (>= 0.8.2),
+    mcstate (>= 0.8.3),
     patchwork,
     readxl,
     reshape2,
@@ -85,7 +85,7 @@ Suggests:
     withr
 Remotes:
     mrc-ide/dust,
-    mrc-ide/mcstate,
+    mrc-ide/mcstate@i179-chains-path,
     mrc-ide/rrq,
     mrc-ide/sircovid
 Config/testthat/edition: 3

--- a/R/control.R
+++ b/R/control.R
@@ -12,6 +12,10 @@
 ##' @param deterministic Logical, indicating if the model to fit to
 ##'   data is run deterministically or stochastically
 ##'
+##' @param multiregion Logical, indicating if we are fitting multiple
+##'   regions at once (in which case even the deterministic model may
+##'   benefit from multithreading).
+##'
 ##' @param date_restart Optionally, dates save restart data in the
 ##'   pmcmc (see [mcstate::pmcmc]
 ##'
@@ -37,14 +41,14 @@
 ##' @return A list of options
 ##' @export
 spim_control <- function(short_run, n_chains, deterministic = FALSE,
-                         date_restart = NULL,
+                         multiregion = FALSE, date_restart = NULL,
                          n_particles = 192, n_mcmc = 1500, burnin = 500,
                          workers = TRUE, n_sample = 1000,
                          n_threads = NULL) {
   if (short_run) {
     n_particles <- min(10, n_particles)
     n_mcmc <- min(20, n_mcmc)
-    n_sample <- 10
+    n_sample <- min(10, n_mcmc)
     burnin <- 1
   }
 
@@ -55,7 +59,8 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
     date_restart <- sircovid::sircovid_date(date_restart)
   }
 
-  parallel <- spim_control_parallel(n_chains, workers, n_threads)
+  parallel <- spim_control_parallel(n_chains, workers, n_threads,
+                                    deterministic, multiregion)
 
   pmcmc <- mcstate::pmcmc_control(n_mcmc,
                                   n_chains = n_chains,
@@ -69,21 +74,9 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
                                   nested_step_ratio = 1, # ignored if single
                                   rerun_every = rerun_every,
                                   rerun_random = TRUE,
-                                  filter_early_exit = TRUE,
+                                  filter_early_exit = !deterministic,
                                   n_burnin = burnin,
                                   n_steps_retain = n_steps_retain)
-
-  if (deterministic) {
-    ## Disable early exit, if it's been set up, as we also don't support that
-    pmcmc$filter_early_exit <- FALSE
-
-    ## Increase the number of workers because each will be running
-    ##   separately. If running on a laptop this probably does not want
-    ##   increasing
-    if (workers) {
-      pmcmc$n_workers <- min(pmcmc$n_chains, pmcmc$n_threads_total)
-    }
-  }
 
   particle_filter <- list(n_particles = n_particles,
                           n_threads = parallel$n_threads_total,
@@ -95,17 +88,38 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
 }
 
 
-## This is only going to be really useful with the single region fit,
-## as we don't really use workers otherwise.
-spim_control_parallel <- function(n_chains, workers, n_threads = NULL,
+spim_control_parallel <- function(n_chains, workers, n_threads,
+                                  deterministic, multiregion,
                                   verbose = TRUE) {
   n_threads <- n_threads %||% spim_control_cores()
+  max_workers <- 4
+
   if (workers) {
-    pos <- 1:4
-    n_workers <- max(pos[n_threads %% pos == 0 & pos <= n_chains])
+    if (deterministic && !multiregion) {
+      ## Increase the number of workers because each will be running
+      ## separately
+      n_workers <- min(n_chains, n_threads)
+      n_threads <- n_workers
+    } else if (deterministic && multiregion) {
+      ## In the case of the deterministic multiregion case, we get
+      ## more from workers (where available) than from within-particle
+      ## parallelisation, so let's try and get these onto up to max
+      ## workers, then increase the number of threads a bit.
+      n_workers <- min(n_chains, n_threads, max_workers)
+      n_threads_given <- n_threads
+      n_threads <- ceiling(n_threads / n_workers) * n_workers
+      if (verbose && n_threads > n_threads_given) {
+        message(sprintf("Increasing total threads from %d to %d",
+                        n_threads_given, n_threads))
+      }
+    } else {
+      pos <- seq_len(max_workers)
+      n_workers <- max(pos[n_threads %% pos == 0 & pos <= n_chains])
+    }
   } else {
     n_workers <- 1L
   }
+
   if (verbose) {
     message(sprintf("Running on %d workers with %d threads",
                     n_workers, n_threads))

--- a/R/control.R
+++ b/R/control.R
@@ -38,13 +38,15 @@
 ##' @param n_threads Explicit number of threads, overriding detection
 ##'   by [spim_control_cores]
 ##'
+##' @param mcmc_path Path to store the mcmc results in
+##'
 ##' @return A list of options
 ##' @export
 spim_control <- function(short_run, n_chains, deterministic = FALSE,
                          multiregion = FALSE, date_restart = NULL,
                          n_particles = 192, n_mcmc = 1500, burnin = 500,
                          workers = TRUE, n_sample = 1000,
-                         n_threads = NULL) {
+                         n_threads = NULL, mcmc_path = NULL) {
   if (short_run) {
     n_particles <- min(10, n_particles)
     n_mcmc <- min(20, n_mcmc)
@@ -76,7 +78,8 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
                                   rerun_random = TRUE,
                                   filter_early_exit = !deterministic,
                                   n_burnin = burnin,
-                                  n_steps_retain = n_steps_retain)
+                                  n_steps_retain = n_steps_retain,
+                                  path = mcmc_path)
 
   particle_filter <- list(n_particles = n_particles,
                           n_threads = parallel$n_threads_total,

--- a/man/spim_control.Rd
+++ b/man/spim_control.Rd
@@ -8,6 +8,7 @@ spim_control(
   short_run,
   n_chains,
   deterministic = FALSE,
+  multiregion = FALSE,
   date_restart = NULL,
   n_particles = 192,
   n_mcmc = 1500,
@@ -25,6 +26,10 @@ will use freer particles, mcmc steps and a small sample}
 
 \item{deterministic}{Logical, indicating if the model to fit to
 data is run deterministically or stochastically}
+
+\item{multiregion}{Logical, indicating if we are fitting multiple
+regions at once (in which case even the deterministic model may
+benefit from multithreading).}
 
 \item{date_restart}{Optionally, dates save restart data in the
 pmcmc (see \link[mcstate:pmcmc]{mcstate::pmcmc}}

--- a/man/spim_control.Rd
+++ b/man/spim_control.Rd
@@ -15,7 +15,8 @@ spim_control(
   burnin = 500,
   workers = TRUE,
   n_sample = 1000,
-  n_threads = NULL
+  n_threads = NULL,
+  mcmc_path = NULL
 )
 }
 \arguments{
@@ -52,6 +53,8 @@ depending on \code{n_chains} and the detected number of cores.}
 
 \item{n_threads}{Explicit number of threads, overriding detection
 by \link{spim_control_cores}}
+
+\item{mcmc_path}{Path to store the mcmc results in}
 }
 \value{
 A list of options

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -139,6 +139,6 @@ test_that("parallel control", {
 
 
 test_that("save path into control", {
-  ctl <- spim_control(TRUE, 4, mcmc_path = "mcmc")
-  expect_equal(ctl$mcmc$path, "mcmc")
+  suppressMessages(ctl <- spim_control(TRUE, 4, mcmc_path = "mcmc"))
+  expect_equal(ctl$pmcmc$path, "mcmc")
 })

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -136,3 +136,9 @@ test_that("parallel control", {
     spim_control_parallel(8, FALSE, 10, TRUE, TRUE, FALSE),
     list(n_threads_total = 10, n_workers = 1))
 })
+
+
+test_that("save path into control", {
+  ctl <- spim_control(TRUE, 4, mcmc_path = "mcmc")
+  expect_equal(ctl$mcmc$path, "mcmc")
+})

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -20,29 +20,29 @@ test_that("Sensible parallel control", {
   mock_cores <- mockery::mock(32, cycle = TRUE)
   mockery::stub(spim_control_parallel, "spim_control_cores", mock_cores)
   expect_equal(
-    spim_control_parallel(4, FALSE, verbose = FALSE),
+    spim_control_parallel(4, FALSE, NULL, FALSE, FALSE, FALSE),
     list(n_threads_total = 32, n_workers = 1))
   mockery::expect_called(mock_cores, 1)
   expect_equal(mockery::mock_args(mock_cores)[[1]], list())
 
   expect_equal(
-    spim_control_parallel(4, FALSE, 32, FALSE),
+    spim_control_parallel(4, FALSE, 32, FALSE, FALSE, FALSE),
     list(n_threads_total = 32, n_workers = 1))
   expect_equal(
-    spim_control_parallel(4, TRUE, 32, FALSE),
+    spim_control_parallel(4, TRUE, 32, FALSE, FALSE, FALSE),
     list(n_threads_total = 32, n_workers = 4))
   expect_equal(
-    spim_control_parallel(8, TRUE, 32, FALSE),
+    spim_control_parallel(8, TRUE, 32, FALSE, FALSE, FALSE),
     list(n_threads_total = 32, n_workers = 4))
   expect_equal(
-    spim_control_parallel(3, TRUE, 32, FALSE),
+    spim_control_parallel(3, TRUE, 32, FALSE, FALSE, FALSE),
     list(n_threads_total = 32, n_workers = 2))
   expect_equal(
-    spim_control_parallel(1, TRUE, 32, FALSE),
+    spim_control_parallel(1, TRUE, 32, FALSE, FALSE, FALSE),
     list(n_threads_total = 32, n_workers = 1))
 
   expect_message(
-    spim_control_parallel(8, TRUE),
+    spim_control_parallel(8, TRUE, 32, FALSE, FALSE, TRUE),
     "Running on 4 workers with 32 threads")
 })
 
@@ -106,4 +106,33 @@ test_that("Can change number of samples", {
   suppressMessages(
     ctrl <- spim_control(FALSE, 8, n_sample = 200, n_mcmc = 1000, burnin = 500))
   expect_equal(ctrl$pmcmc$n_steps_retain, 25) # i.e., 25 * 8 == 200
+})
+
+
+test_that("parallel control", {
+  expect_equal(
+    spim_control_parallel(8, TRUE, 16, FALSE, FALSE, FALSE),
+    list(n_threads_total = 16, n_workers = 4))
+  expect_equal(
+    spim_control_parallel(8, TRUE, 16, TRUE, FALSE, FALSE),
+    list(n_threads_total = 8, n_workers = 8))
+  expect_equal(
+    spim_control_parallel(8, TRUE, 16, TRUE, TRUE, FALSE),
+    list(n_threads_total = 16, n_workers = 4))
+  expect_equal(
+    spim_control_parallel(8, TRUE, 10, TRUE, TRUE, FALSE),
+    list(n_threads_total = 12, n_workers = 4))
+
+  expect_equal(
+    spim_control_parallel(8, FALSE, 16, FALSE, FALSE, FALSE),
+    list(n_threads_total = 16, n_workers = 1))
+  expect_equal(
+    spim_control_parallel(8, FALSE, 16, TRUE, FALSE, FALSE),
+    list(n_threads_total = 16, n_workers = 1))
+  expect_equal(
+    spim_control_parallel(8, FALSE, 16, TRUE, TRUE, FALSE),
+    list(n_threads_total = 16, n_workers = 1))
+  expect_equal(
+    spim_control_parallel(8, FALSE, 10, TRUE, TRUE, FALSE),
+    list(n_threads_total = 10, n_workers = 1))
 })


### PR DESCRIPTION
This has been ick for a while, worse now that the deterministic multiregion does want some workers.

Requires https://github.com/mrc-ide/mcstate/pull/191 - branch pin should be removed before merge