### PR TITLE
Allow control over compiled compare

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.6.10
+Version: 0.6.11
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/control.R
+++ b/R/control.R
@@ -38,7 +38,14 @@
 ##' @param n_threads Explicit number of threads, overriding detection
 ##'   by [spim_control_cores]
 ##'
+##' @param compiled_compare Use a compiled compare function (rather
+##'   than the R version).  This can speed things up with the
+##'   deterministic models in particular.
+##'
 ##' @param mcmc_path Path to store the mcmc results in
+##'
+##' @param verbose Logical, indicating if we should print information
+##'   about the parallel configuration
 ##'
 ##' @return A list of options
 ##' @export
@@ -46,7 +53,8 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
                          multiregion = FALSE, date_restart = NULL,
                          n_particles = 192, n_mcmc = 1500, burnin = 500,
                          workers = TRUE, n_sample = 1000,
-                         n_threads = NULL, mcmc_path = NULL) {
+                         n_threads = NULL, compiled_compare = FALSE,
+                         mcmc_path = NULL, verbose = TRUE) {
   if (short_run) {
     n_particles <- min(10, n_particles)
     n_mcmc <- min(20, n_mcmc)
@@ -62,7 +70,8 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
   }
 
   parallel <- spim_control_parallel(n_chains, workers, n_threads,
-                                    deterministic, multiregion)
+                                    deterministic, multiregion,
+                                    verbose)
 
   pmcmc <- mcstate::pmcmc_control(n_mcmc,
                                   n_chains = n_chains,
@@ -81,10 +90,11 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
                                   n_steps_retain = n_steps_retain,
                                   path = mcmc_path)
 
+  n_threads <- parallel$n_threads_total / parallel$n_workers
   particle_filter <- list(n_particles = n_particles,
-                          n_threads = parallel$n_threads_total,
+                          n_threads = n_threads,
                           seed = NULL,
-                          compiled_compare = FALSE)
+                          compiled_compare = compiled_compare)
 
   list(pmcmc = pmcmc,
        particle_filter = particle_filter)

--- a/man/spim_control.Rd
+++ b/man/spim_control.Rd
@@ -16,7 +16,9 @@ spim_control(
   workers = TRUE,
   n_sample = 1000,
   n_threads = NULL,
-  mcmc_path = NULL
+  compiled_compare = FALSE,
+  mcmc_path = NULL,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -54,7 +56,14 @@ depending on \code{n_chains} and the detected number of cores.}
 \item{n_threads}{Explicit number of threads, overriding detection
 by \link{spim_control_cores}}
 
+\item{compiled_compare}{Use a compiled compare function (rather
+than the R version).  This can speed things up with the
+deterministic models in particular.}
+
 \item{mcmc_path}{Path to store the mcmc results in}
+
+\item{verbose}{Logical, indicating if we should print information
+about the parallel configuration}
 }
 \value{
 A list of options

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -154,3 +154,12 @@ test_that("Don't rerun deterministic models", {
       spim_control(FALSE, 4, deterministic = TRUE)$pmcmc$rerun_every),
     Inf)
 })
+
+
+test_that("Control compiled compare", {
+  ctl <- spim_control(TRUE, 4, verbose = FALSE)
+  expect_false(ctl$particle_filter$compiled_compare)
+
+  ctl <- spim_control(TRUE, 4, compiled_compare = TRUE, verbose = FALSE)
+  expect_true(ctl$particle_filter$compiled_compare)
+})


### PR DESCRIPTION
Just exposes a control parameter already handled by mcstate, useful for deterministic models