### PR TITLE
discrete is deprecated in mcstate, replace with integer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Imports:
     khroma,
     lubridate,
     matrixStats,
-    mcstate (>= 0.8.3),
+    mcstate (>= 0.9.0),
     patchwork,
     readxl,
     reshape2,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.7.9
+Version: 0.7.10
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/pars.R
+++ b/R/pars.R
@@ -67,7 +67,7 @@ spim_pars_check_beta_date <- function(beta_date) {
 
 spim_pars_info_single <- function(region, info) {
   assert_has_names(info, c("region", "include",
-                           "name", "initial", "max", "discrete"))
+                           "name", "initial", "max", "integer"))
   if (!(region %in% info$region)) {
     stop(sprintf("Did not find region '%s' in parameter info", region))
   }
@@ -81,7 +81,7 @@ spim_pars_info_single <- function(region, info) {
 
 spim_pars_info_nested <- function(region, info) {
   assert_has_names(info, c("region", "include", "name", "initial",
-                           "max", "discrete"))
+                           "max", "integer"))
   msg <- setdiff(region, info$region)
   if (length(msg) > 0) {
     stop(sprintf("Did not find region %s in parameter info",
@@ -223,13 +223,13 @@ make_prior <- function(d) {
 ##' @param prior List of values for the prior (must include "type",
 ##'   then other values for the prior data.frame)
 ##'
-##' @param discrete Logical, indicates if discrete
+##' @param integer Logical, indicates if integer
 ##'
 ##' @param include Logical, indicates if fitted
 ##'
 ##' @export
 spim_add_par <- function(pars, name, initial, min, max, proposal_variance,
-                         prior, discrete = FALSE, include = TRUE) {
+                         prior, integer = FALSE, include = TRUE) {
   assert_is(pars, "spim_pars_pmcmc")
 
   new_par <- data_frame(
@@ -238,7 +238,7 @@ spim_add_par <- function(pars, name, initial, min, max, proposal_variance,
     initial = initial,
     min = min,
     max = max,
-    discrete = discrete,
+    integer = integer,
     include = include)
   pars$info <- rbind(pars$info, new_par)
   pars$info <- pars$info[order(pars$info$region, pars$info$name), ]
@@ -298,7 +298,7 @@ spim_pars_mcmc_single <- function(info, prior, proposal, transform) {
     initial = info$initial,
     min = info$min,
     max = info$max,
-    discrete = info$discrete,
+    integer = info$integer,
     prior = lapply(split(prior, prior$name), make_prior))
 
   ret <- mcstate::pmcmc_parameters$new(pars_mcmc, proposal, transform)
@@ -319,7 +319,7 @@ spim_pars_mcmc_nested <- function(info, prior, proposal, transform) {
     initial = info$fixed$initial,
     min = info$fixed$min,
     max = info$fixed$max,
-    discrete = info$fixed$discrete,
+    integer = info$fixed$integer,
     prior = prior_fixed)
 
   ## These could be done per region, or could be done separately.  I
@@ -335,7 +335,7 @@ spim_pars_mcmc_nested <- function(info, prior, proposal, transform) {
       initial = info$varied[[i]]$initial,
       min = info$varied[[i]]$min,
       max = info$varied[[i]]$max,
-      discrete = info$varied[[i]]$discrete[[1]],
+      integer = info$varied[[i]]$integer[[1]],
       prior = prior_varied[[i]]))
   names(pars_varied) <- names(info$varied)
 

--- a/man/spim_add_par.Rd
+++ b/man/spim_add_par.Rd
@@ -13,7 +13,7 @@ spim_add_par(
   max,
   proposal_variance,
   prior,
-  discrete = FALSE,
+  integer = FALSE,
   include = TRUE
 )
 
@@ -35,7 +35,7 @@ spim_add_par_beta(pars)
 \item{prior}{List of values for the prior (must include "type",
 then other values for the prior data.frame)}
 
-\item{discrete}{Logical, indicates if discrete}
+\item{integer}{Logical, indicates if integer}
 
 \item{include}{Logical, indicates if fitted}
 }

--- a/tests/testthat/helper-spimalot.R
+++ b/tests/testthat/helper-spimalot.R
@@ -2,7 +2,7 @@ test_dummy_pars_pmcmc <- function(vars, regions = NULL) {
   regions <- regions %||% sircovid::regions("all")
   info <- lapply(regions, function(r)
     data_frame(region = r, name = vars, initial = runif(length(vars)),
-               min = 0, max = 1, discrete = FALSE, include = TRUE))
+               min = 0, max = 1, integer = FALSE, include = TRUE))
   info <- dplyr::bind_rows(info)
 
   prior <- lapply(regions, function(r)

--- a/tests/testthat/test-pars.R
+++ b/tests/testthat/test-pars.R
@@ -59,7 +59,7 @@ test_that("filter info by region", {
   dat <- test_dummy_pars_pmcmc(c("a", "b", "c"))
   info <- spim_pars_info_single("london", dat$info)
   expect_equal(nrow(info), 3)
-  expect_setequal(names(info), c("name", "initial", "min", "max", "discrete"))
+  expect_setequal(names(info), c("name", "initial", "min", "max", "integer"))
   expect_error(
     spim_pars_info_single("islington", dat$info),
     "Did not find region 'islington' in parameter info")


### PR DESCRIPTION
The "discrete" option has been deprecated in mcstate and replaced with integer (https://github.com/mrc-ide/mcstate/pull/205)