### PR TITLE
Re-enable deterministic compiled compare

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.7.12
+Version: 0.7.13
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",
@@ -60,7 +60,7 @@ Imports:
     coda,
     distr6,
     dplyr,
-    dust (>= 0.11.20),
+    dust (>= 0.11.25),
     epitrix,
     extrafont,
     ggnewscale,
@@ -74,7 +74,7 @@ Imports:
     patchwork,
     readxl,
     reshape2,
-    sircovid (>= 0.13.7),
+    sircovid (>= 0.13.8),
     stringr,
     tdigest,
     tibble,

--- a/R/control.R
+++ b/R/control.R
@@ -63,12 +63,6 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
     burnin <- 1
   }
 
-  if (multiregion) {
-    ## Temporary fix as there is currently an issue with history reporting
-    ## in mcstate for multiregion when the compiled compare is used
-    compiled_compare <- FALSE
-  }
-
   n_steps_retain <- ceiling(n_sample / n_chains)
 
   rerun_every <- if (deterministic) Inf else 100


### PR DESCRIPTION
Largely reverts #201/31f0d8 now that sircovid and dust changes are complete