### PR TITLE
Compatibility patch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.7.16
+Version: 0.7.17
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/fit.R
+++ b/R/fit.R
@@ -103,7 +103,8 @@ spim_particle_filter <- function(data, pars, control,
 ##' @export
 spim_fit_run <- function(pars, filter, control) {
   message("Running chains - this will take a while!")
-  multiregion <- filter$nested
+  ## compatibility for the next version of mcstate:
+  multiregion <- filter$has_multiple_data %||% filter$nested
   if (multiregion) {
     initial <- replicate(control$n_chains,
                          pars$mcmc$propose(pars$mcmc$initial(), "both", 1))


### PR DESCRIPTION
I'm changing the name of the filter's `$nested` field to `$has_multiple_data` (I think that you'll agree it's clearer).  This PR will work with the existing version and also the new one