### PR TITLE
Ons deaths for DVN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.8.3
+Version: 0.8.4
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",


### PR DESCRIPTION
We are no longer being sent deaths data for Wales and Scotland, but we do have ONS deaths data for all nations. So, we setup to fit to ONS deaths by place/age for all regions, and then in the last 45 days:

- England: linelist deaths by place/age (same as before)
- Scotland: no deaths data
- Wales: no deaths data
- Northern Ireland: aggregated deaths data (what we used for the whole time series before)