### PR TITLE
Restart initial round

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.8.4
+Version: 0.8.5
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/fit_restart.R
+++ b/R/fit_restart.R
@@ -53,7 +53,11 @@ spim_restart_initial_state <- function(restart, date, round = FALSE) {
 
     idx_states_to_round <- c(unlist(info$index[states_to_round]))
 
-    ret[idx_states_to_round, ] <- round(ret[idx_states_to_round, ])
+    random_round <- function(x) {
+      floor(x) + rbinom(prod(dim(x)), 1, x - floor(x))
+    }
+
+    ret[idx_states_to_round, ] <- random_round(ret[idx_states_to_round, ])
   }
 
   ret

--- a/man/spim_restart_initial_state.Rd
+++ b/man/spim_restart_initial_state.Rd
@@ -4,7 +4,7 @@
 \alias{spim_restart_initial_state}
 \title{Load restart data}
 \usage{
-spim_restart_initial_state(restart, date)
+spim_restart_initial_state(restart, date, round = FALSE)
 }
 \arguments{
 \item{restart}{The loaded restart date (processed with
@@ -17,6 +17,11 @@ by particle by \code{time}).}
 passed through \link[sircovid:sircovid_date]{sircovid::as_sircovid_date} so can be either an
 integer sircovid date, an R Date or a string representing an ISO
 date.}
+
+\item{round}{Logical parameter, indicates whether or not to round
+the main model states. Can be used to ensure that a restart initial
+state from a deterministic parent fit can be used in a stochastic
+restart fit. Default is FALSE}
 }
 \value{
 A list with the same names as \code{restart}, but with


### PR DESCRIPTION
Adds the option to round the main model compartments for the initial restart state. This is necessary for switching from a deterministic parent fit to a stochastic restart fit.

The rounding is done randomly, as in some cases the deterministic version will have lots of small amounts (< 0.5) which all round to zero. This way the mean of the rounding should equal the value being rounded.