### PR TITLE
end BA.2 vs BA.4/BA.5 data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.8.6
+Version: 0.8.7
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",
@@ -74,7 +74,7 @@ Imports:
     patchwork,
     readxl,
     reshape2,
-    sircovid (>= 0.14.1),
+    sircovid (>= 0.14.2),
     stringr,
     tdigest,
     tibble,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,7 +88,7 @@ Suggests:
     testthat,
     withr
 Remotes:
-    alan-turing-institute/distr6
+    alan-turing-institute/distr6,
     mrc-ide/dust,
     mrc-ide/mcstate,
     mrc-ide/rrq,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,6 +88,7 @@ Suggests:
     testthat,
     withr
 Remotes:
+    alan-turing-institute/distr6
     mrc-ide/dust,
     mrc-ide/mcstate,
     mrc-ide/rrq,

--- a/R/data.R
+++ b/R/data.R
@@ -349,7 +349,7 @@ spim_lancelot_data_rtm <- function(date, region, model_type, data,
 
   ## Fit to Omicron BA.2/Omicron BA.4 & BA.5
   omicron_ba2_ba4ba5_dates <-
-    data$date > "2022-04-15" & data$date <= date
+    data$date > "2022-04-15" & data$date < "2022-08-01"
   data$strain_non_variant[omicron_ba2_ba4ba5_dates] <-
     data$n_all_omicron_ba2_variant[omicron_ba2_ba4ba5_dates]
     data$strain_tot[omicron_ba2_ba4ba5_dates] <-


### PR DESCRIPTION
- Set an end date for fitting BA.2 vs BA.4/BA.5 (now that BA.4/BA.5 have replaced BA.2)
- Add distr6 to remotes because it's been removed from CRAN