### PR TITLE
Fix severity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.8.7
+Version: 0.8.8
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",
@@ -74,7 +74,7 @@ Imports:
     patchwork,
     readxl,
     reshape2,
-    sircovid (>= 0.14.2),
+    sircovid (>= 0.14.3),
     stringr,
     tdigest,
     tibble,

--- a/R/combined.R
+++ b/R/combined.R
@@ -383,6 +383,11 @@ combined_severity_1 <- function(severity, samples, what, weight,
                                 step_date = FALSE) {
   for (i in names(severity)) {
     severity[[i]] <- severity[[i]][c(what, "step", "date")]
+    zero_weight <-
+      which(t(samples[[i]]$trajectories$state[weight, , ]) == 0)
+    for (w in what) {
+      severity[[i]][[w]][zero_weight] <- 0
+    }
   }
 
   ret <- sircovid::combine_rt(severity, samples,

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -1012,6 +1012,7 @@ extract_severity_region <- function(state, step, date) {
 
   severity$step <- step
   severity$date <- date
+  class(severity) <- "IFR_t_trajectories"
 
   severity
 }

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -1002,6 +1002,7 @@ extract_severity_region <- function(state, step, date) {
 
   # ignore CHR and CHW
   sev_traj <- grep("CHR|CHW", sev_traj, invert = TRUE, value = TRUE)
+  sev_traj <- grep("disag", sev_traj, invert = TRUE, value = TRUE)
 
   severity <- list()
 

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -1002,7 +1002,6 @@ extract_severity_region <- function(state, step, date) {
 
   # ignore CHR and CHW
   sev_traj <- grep("CHR|CHW", sev_traj, invert = TRUE, value = TRUE)
-  sev_traj <- grep("disag", sev_traj, invert = TRUE, value = TRUE)
 
   severity <- list()
 


### PR DESCRIPTION
Fixes some things re severity: first make sure they are ranked in the same way other things are. Secondly things are then weighted in aggregation by the corresponding incidence. e.g. rather than weight HFR for 20-24 by all hospitalisations incidence, we weight by 20-24 hospitalisations incidence.

Requires https://github.com/mrc-ide/sircovid/pull/425