### PR TITLE
Keep strains rt

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,7 +74,7 @@ Imports:
     patchwork,
     readxl,
     reshape2,
-    sircovid (>= 0.14.4),
+    sircovid (>= 0.14.5),
     stringr,
     tdigest,
     tibble,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.8.12
+Version: 0.8.13
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/combined.R
+++ b/R/combined.R
@@ -629,7 +629,6 @@ combine_variant_rt <- function(variant_rt, samples, rank, weighted = FALSE) {
     variant_weighted <- combine_variant_rt_j(3)
   }
 
-
   ## finally we join the variants together
   ret <- variant1
   for (w in what) {

--- a/R/combined_spim.R
+++ b/R/combined_spim.R
@@ -147,7 +147,7 @@ spim_summary_region_rt <-  function(region, dat, time_series_date) {
   model_type <- dat$info$model_type
   qs <- spim_summary_quantiles()
 
-  rt <- dat$rt[[region]]$eff_Rt_general
+  rt <- dat$rt[[region]]$eff_Rt_general[, "weighted", ]
   rt_date <- dat$rt[[region]]$date[, 1]
 
   ## This can be considerably simplified

--- a/R/control.R
+++ b/R/control.R
@@ -19,6 +19,12 @@
 ##' @param severity Logical, indicating if we are outputting severity
 ##'   trajectories (e.g. IFR, IHR, HFR). Default to FALSE.
 ##'
+##' @param simulate Logical, indicating if we are outputting a simulate object
+##'   for onward simulation
+##'
+##' @param demography Logical, indicating if we are outputting model
+##'   demography - admissions and deaths by age
+##'
 ##' @param date_restart Optionally, dates save restart data in the
 ##'   pmcmc (see [mcstate::pmcmc]
 ##'
@@ -59,6 +65,7 @@
 ##' @export
 spim_control <- function(short_run, n_chains, deterministic = FALSE,
                          multiregion = FALSE, severity = FALSE,
+                         simulate = FALSE, demography = FALSE,
                          date_restart = NULL, n_particles = 192, n_mcmc = 1500,
                          burnin = 500, workers = TRUE, n_sample = 1000,
                          n_threads = NULL, compiled_compare = FALSE,
@@ -114,7 +121,9 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
                           n_threads = n_threads,
                           seed = NULL,
                           compiled_compare = compiled_compare,
-                          severity = severity)
+                          severity = severity,
+                          simulate = simulate,
+                          demography = demography)
 
   list(pmcmc = pmcmc,
        particle_filter = particle_filter)

--- a/R/fit.R
+++ b/R/fit.R
@@ -71,12 +71,23 @@ spim_particle_filter <- function(data, pars, control,
     assert_is(initial, "function")
   }
 
+  ## Logical flags for the index function
+  severity <- control$severity
+  protected <- control$severity
+  cum_infections_disag <- control$simulate
+  D_all <- control$demography || control$simulate
+  D_hosp <- control$demography || control$severity || control$simulate
+  diagnoses_admitted <- control$severity || control$simulate
+
   if (deterministic) {
     mcstate::particle_deterministic$new(
       data = data, model = sircovid::lancelot, compare = compare,
       index = function(info)
-        sircovid::lancelot_index(info, severity = control$severity,
-                                 protected = control$severity),
+        sircovid::lancelot_index(info, severity = severity,
+                                 protected = protected,
+                                 D_all = D_all, D_hosp = D_hosp,
+                                 diagnoses_admitted = diagnoses_admitted,
+                                 cum_infections_disag = cum_infections_disag),
       initial = initial,
       n_threads = control$n_threads)
   } else {
@@ -84,8 +95,11 @@ spim_particle_filter <- function(data, pars, control,
       data = data, model = sircovid::lancelot,
       n_particles = control$n_particles,
       compare = compare, index = function(info)
-        sircovid::lancelot_index(info, severity = control$severity,
-                                 protected = control$severity),
+        sircovid::lancelot_index(info, severity = severity,
+                                 protected = protected,
+                                 D_all = D_all, D_hosp = D_hosp,
+                                 diagnoses_admitted = diagnoses_admitted,
+                                 cum_infections_disag = cum_infections_disag),
       initial = initial,
       n_threads = control$n_threads, seed = control$seed)
   }

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -15,12 +15,8 @@
 ##'   [spimalot::spim_control()]. It will be used here to check for switches of
 ##'   particular trajectories to be outputed (e.g. `severity`).
 ##'
-##' @param simulate_object set to TRUE for almost all cases, if you don't want
-##'    your fits for a simulation then switch to FALSE
-##'
 ##' @export
-spim_fit_process <- function(samples, parameters, data, control,
-                            simulate_object = TRUE) {
+spim_fit_process <- function(samples, parameters, data, control) {
   region <- samples$info$region
 
   ## This is just the info/prior/proposal + base of the parameter used
@@ -44,16 +40,23 @@ spim_fit_process <- function(samples, parameters, data, control,
   ## filter trajectories to start at this date) and when we might
   ## change it.
 
-  if (simulate_object == TRUE) {
+  if (control$simulate) {
     message("Preparing onward simulation object")
     start_date_sim <- "2021-06-01"
     simulate <- create_simulate_object(samples, start_date_sim,
                                         samples$info$date)
+  } else {
+    simulate <- NULL
   }
 
   ## Extract demography
-  message("Extracting demography")
-  model_demography <- extract_demography(samples)
+  if (control$severity) {
+    message("Extracting demography")
+    model_demography <- extract_demography(samples)
+  } else {
+    model_demography <- NULL
+  }
+
 
   ## Check severity is TRUE extract
   if (control$severity) {

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -208,8 +208,6 @@ calculate_lancelot_Rt_region <- function(pars, state, transform,
              eff_Rt_general = numeric(0),
              Rt_general = numeric(0))
 
-
-
   for (i in seq_len(length(epoch_dates) + 1L)) {
     if (i == 1) {
       dates1 <- which(dates <= epoch_dates[1])
@@ -417,8 +415,6 @@ rt_filter_time <- function(rt, i, multiregion) {
     ret
   }
 }
-
-
 
 
 deaths_filter_time <- function(x, restart_date) {

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -402,7 +402,7 @@ rt_filter_time <- function(rt, i, multiregion) {
     lapply(rt, rt_filter_time, i, FALSE)
   } else {
     rt_filter_time1 <- function(x) {
-      if (length(dim(rt)) == 2) {
+      if (length(dim(x)) == 2) {
         ret <- x[i, , drop = FALSE]
       } else {
         ret <- x[i, , , drop = FALSE]

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -33,8 +33,7 @@ spim_fit_process <- function(samples, parameters, data, control) {
   ## The Rt calculation is slow and runs in serial; it's a surprising
   ## fraction of the total time.
   message("Computing Rt")
-  rt <- calculate_lancelot_Rt(samples, TRUE)
-  variant_rt <- calculate_lancelot_Rt(samples, FALSE)
+  rt <- calculate_lancelot_Rt(samples, TRUE, TRUE)
 
   ## TODO: someone needs to document what this date is for (appears to
   ## filter trajectories to start at this date) and when we might
@@ -94,7 +93,6 @@ spim_fit_process <- function(samples, parameters, data, control) {
   ## 1. 'fit' list of;
   ## samples - reduced mcstate trajectory samples
   ## rt - calculated spimalot lancelot Rt value (calculate_lancelot_Rt output)
-  ## variant_rt - variant specific Rt
   ## simulate - object containing spimalot objects (used for onward simulation)
   ##            such as; thinned samples, start date of sim, samples date.
   ## parameters - parameter MLE and covariance matrix
@@ -108,7 +106,6 @@ spim_fit_process <- function(samples, parameters, data, control) {
     fit = list(samples = samples,
                rt = rt,
                severity = severity,
-               variant_rt = variant_rt,
                simulate = simulate,
                parameters = parameters_new,
                model_demography = model_demography,
@@ -153,7 +150,7 @@ create_simulate_object <- function(samples, start_date_sim, date) {
 }
 
 
-calculate_lancelot_Rt <- function(samples, weight_Rt) {
+calculate_lancelot_Rt <- function(samples, weight_Rt, keep_strains_Rt = FALSE) {
   step <- samples$trajectories$step
   info <- samples$info$info
   epoch_dates <- samples$info$epoch_dates
@@ -168,18 +165,21 @@ calculate_lancelot_Rt <- function(samples, weight_Rt) {
     ## pars, state, step, info, epoch_dates
     ret <- lapply(samples$info$region, function(r)
       calculate_lancelot_Rt_region(pars[, , r], state[, r, , ], transform[[r]],
-                                   step, info, epoch_dates, weight_Rt))
+                                   step, info, epoch_dates, weight_Rt,
+                                   keep_strains_Rt))
     names(ret) <- samples$info$region
   } else {
     ret <- calculate_lancelot_Rt_region(pars, state, transform,
-                                        step, info, epoch_dates, weight_Rt)
+                                        step, info, epoch_dates, weight_Rt,
+                                        keep_strains_Rt)
   }
   ret
 }
 
 
 calculate_lancelot_Rt_region <- function(pars, state, transform,
-                                         step, info, epoch_dates, weight_Rt) {
+                                         step, info, epoch_dates, weight_Rt,
+                                         keep_strains_Rt) {
   index_S <- grep("^S_", rownames(state))
   index_R <- grep("^R_", rownames(state))
   index_ps <- grep("^prob_strain", rownames(state))
@@ -195,16 +195,20 @@ calculate_lancelot_Rt_region <- function(pars, state, transform,
   pars_model[[1]]$steps_per_day
   dates <- step / 4
 
+  n_pars <- nrow(pars)
+
+  type <- c("eff_Rt_general", "Rt_general")
+
   ## TODO: currently we'll just deal with multistage here, but it would
   ## be good to adapt the sircovid function to deal with multistage
   ## parameters
   rt <- list(step = numeric(0),
              date = numeric(0),
              beta = numeric(0),
-             eff_Rt_all = numeric(0),
              eff_Rt_general = numeric(0),
-             Rt_all = numeric(0),
              Rt_general = numeric(0))
+
+
 
   for (i in seq_len(length(epoch_dates) + 1L)) {
     if (i == 1) {
@@ -243,21 +247,42 @@ calculate_lancelot_Rt_region <- function(pars, state, transform,
       prob_strain1 <- prob_strain[, , dates1, drop = FALSE]
     }
 
-    if (!(n_strains == 1 && !weight_Rt)) {
-      rt1 <- sircovid::lancelot_Rt_trajectories(
-        step1, S1, pars_model[[i]],
-        initial_step_from_parameters = initial_step_from_parameters,
-        shared_parameters = FALSE, R = R1, prob_strain = prob_strain1,
-        weight_Rt = weight_Rt)
-      for (nm in names(rt)) {
-        if (length(rt[[nm]]) == 0) {
-          rt[[nm]] <- rt1[[nm]]
-        } else if (length(dim(rt1[[nm]])) == 2) {
-          rt[[nm]] <- rbind(rt[[nm]], rt1[[nm]])
-        } else {
-          rt[[nm]] <- abind1(rt[[nm]], rt1[[nm]])
+    rt1 <- sircovid::lancelot_Rt_trajectories(
+      step1, S1, pars_model[[i]], type = type,
+      initial_step_from_parameters = initial_step_from_parameters,
+      shared_parameters = FALSE, R = R1, prob_strain = prob_strain1,
+      weight_Rt = weight_Rt, keep_strains_Rt = keep_strains_Rt)
+
+    reshape_rt <- function(r) {
+      if (weight_Rt) {
+        tmp <- array(NA, c(length(step1), 3, n_pars))
+        tmp[, 3, ] <- r
+      } else {
+        tmp <- array(NA, c(length(step1), 2, n_pars))
+      }
+      tmp[, 1, ] <- r
+      tmp
+    }
+
+    for (nm in names(rt)) {
+      if (n_strains == 1 && !(weight_Rt && !keep_strains_Rt)) {
+        if (nm %in% type) {
+          rt1[[nm]] <- reshape_rt(rt1[[nm]])
         }
       }
+      if (length(rt[[nm]]) == 0) {
+        rt[[nm]] <- rt1[[nm]]
+      } else if (length(dim(rt1[[nm]])) == 2) {
+        rt[[nm]] <- rbind(rt[[nm]], rt1[[nm]])
+      } else {
+        rt[[nm]] <- abind1(rt[[nm]], rt1[[nm]])
+      }
+    }
+  }
+
+  if (weight_Rt && keep_strains_Rt) {
+    for (nm in type) {
+      colnames(rt[[nm]]) <- c("strain_1", "strain_2", "weighted")
     }
   }
 
@@ -374,14 +399,26 @@ trajectories_filter_time <- function(trajectories, i) {
 
 
 rt_filter_time <- function(rt, i, multiregion) {
+
   if (multiregion) {
     lapply(rt, rt_filter_time, i, FALSE)
   } else {
-    ret <- lapply(rt, function(x) x[i, , drop = FALSE])
+    rt_filter_time1 <- function(x) {
+      if (length(dim(rt)) == 2) {
+        ret <- x[i, , drop = FALSE]
+      } else {
+        ret <- x[i, , , drop = FALSE]
+      }
+      ret
+    }
+
+    ret <- lapply(rt, function(x) rt_filter_time1)
     class(ret) <- class(rt)
     ret
   }
 }
+
+
 
 
 deaths_filter_time <- function(x, restart_date) {

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -410,7 +410,7 @@ rt_filter_time <- function(rt, i, multiregion) {
       ret
     }
 
-    ret <- lapply(rt, function(x) rt_filter_time1)
+    ret <- lapply(rt, rt_filter_time1)
     class(ret) <- class(rt)
     ret
   }

--- a/R/fit_restart.R
+++ b/R/fit_restart.R
@@ -157,6 +157,7 @@ spim_restart_join_parent <- function(fit, parent) {
         out <- rbind(a[i, , drop = FALSE], b[-1L, ])
       } else if (length(dim(a)) == 3){
         out <- abind1(a[i, , , drop = FALSE], b[-1L, , ])
+        colnames(out) <- c("strain_1", "strain_2", "weighted")
       }
       out
     }

--- a/R/fit_restart.R
+++ b/R/fit_restart.R
@@ -152,8 +152,16 @@ spim_restart_join_parent <- function(fit, parent) {
     fit$samples$trajectories$state)
 
   join_rt <- function(parent, new, i) {
-    ret <- Map(function(a, b) rbind(a[i, , drop = FALSE], b[-1L, ]),
-               parent, new)
+    join_rt1 <- function(a, b) {
+      if (length(dim(a)) == 2) {
+        out <- rbind(a[i, , drop = FALSE], b[-1L, ])
+      } else if (length(dim(a)) == 3){
+        out <- abind1(a[i, , , drop = FALSE], b[-1L, , ])
+      }
+      out
+    }
+
+    ret <- Map(join_rt1, parent, new)
     class(ret) <- class(new)
     ret
   }

--- a/R/fit_restart.R
+++ b/R/fit_restart.R
@@ -155,7 +155,7 @@ spim_restart_join_parent <- function(fit, parent) {
     join_rt1 <- function(a, b) {
       if (length(dim(a)) == 2) {
         out <- rbind(a[i, , drop = FALSE], b[-1L, ])
-      } else if (length(dim(a)) == 3){
+      } else if (length(dim(a)) == 3) {
         out <- abind1(a[i, , , drop = FALSE], b[-1L, , ])
         colnames(out) <- c("strain_1", "strain_2", "weighted")
       }

--- a/R/plot_combined.R
+++ b/R/plot_combined.R
@@ -1665,7 +1665,11 @@ spim_plot_Rt_region <- function(region, dat, rt_type, forecast_until,
 
   beta_date <- dat$info$beta_date
   if (variant == "weighted") {
-    sample_Rt <- dat$rt[[region]][[rt_type]][-1L, ]
+    if (rt_type == "beta") {
+      sample_Rt <- dat$rt[[region]][[rt_type]][-1L, ]
+    } else {
+      sample_Rt <- dat$rt[[region]][[rt_type]][-1L, "weighted", ]
+    }
     x <- sircovid::sircovid_date_as_date(dat$rt[[region]]$date[-1L, 1])
   } else {
     if (variant == "delta") {

--- a/R/plot_combined.R
+++ b/R/plot_combined.R
@@ -743,9 +743,9 @@ spim_plot_log_traj_by_age_region1 <- function(region, dat, yield, what,
 
     if (what == "under15") {
       ylab <- spim_region_name(region)
-    } else (
+    } else {
       ylab <- ""
-    )
+    }
 
     oo <- par(mgp = c(1.7, 0.5, 0), bty = "n")
     on.exit(oo)

--- a/man/spim_control.Rd
+++ b/man/spim_control.Rd
@@ -10,6 +10,8 @@ spim_control(
   deterministic = FALSE,
   multiregion = FALSE,
   severity = FALSE,
+  simulate = FALSE,
+  demography = FALSE,
   date_restart = NULL,
   n_particles = 192,
   n_mcmc = 1500,
@@ -38,6 +40,12 @@ benefit from multithreading).}
 
 \item{severity}{Logical, indicating if we are outputting severity
 trajectories (e.g. IFR, IHR, HFR). Default to FALSE.}
+
+\item{simulate}{Logical, indicating if we are outputting a simulate object
+for onward simulation}
+
+\item{demography}{Logical, indicating if we are outputting model
+demography - admissions and deaths by age}
 
 \item{date_restart}{Optionally, dates save restart data in the
 pmcmc (see \link[mcstate:pmcmc]{mcstate::pmcmc}}

--- a/man/spim_fit_process.Rd
+++ b/man/spim_fit_process.Rd
@@ -4,7 +4,7 @@
 \alias{spim_fit_process}
 \title{Process a fit for \code{lancelot} model}
 \usage{
-spim_fit_process(samples, parameters, data, control, simulate_object = TRUE)
+spim_fit_process(samples, parameters, data, control)
 }
 \arguments{
 \item{samples}{The pmcmc_samples object from \link[mcstate:pmcmc]{mcstate::pmcmc}}
@@ -19,9 +19,6 @@ spim_fit_process(samples, parameters, data, control, simulate_object = TRUE)
 \code{particle_filter} element of the result of
 \code{\link[=spim_control]{spim_control()}}. It will be used here to check for switches of
 particular trajectories to be outputed (e.g. \code{severity}).}
-
-\item{simulate_object}{set to TRUE for almost all cases, if you don't want
-your fits for a simulation then switch to FALSE}
 }
 \description{
 Process fit data for \code{lancelot} model


### PR DESCRIPTION
Trims down the Rt calculation, to save time in the fit process function. Requires
https://github.com/mrc-ide/sircovid/pull/429

Also includes changes in https://github.com/mrc-ide/spimalot/pull/241