### PR TITLE
Refactor pillar2 positivity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.8.13
+Version: 0.8.14
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -733,7 +733,7 @@ calculate_negatives_region <- function(state, pars_model, date) {
   neg <- aperm(neg, c(3, 1, 2))
   rownames(neg) <- pillar2_age_bands
 
-  agg_age_bands <- function(x, name) {
+  aggregate_age_bands <- function(x, name) {
     agg <- apply(x, c(2, 3), sum)
     agg <- array(agg, c(1, dim(agg)))
     rownames(agg) <- name
@@ -741,9 +741,8 @@ calculate_negatives_region <- function(state, pars_model, date) {
   }
 
   ## Calculate the negatives for aggregated age bands
-  neg <- abind1(neg, agg_age_bands(neg[pillar2_age_bands, , ], ""))
-  neg <-
-    abind1(neg, agg_age_bands(neg[over25_age_bands, , ], "_over25"))
+  neg <- abind1(neg, aggregate_age_bands(neg[pillar2_age_bands, , ], ""))
+  neg <- abind1(neg, aggregate_age_bands(neg[over25_age_bands, , ], "_over25"))
   rownames(neg) <- paste0("pillar2_negs", rownames(neg))
 
   neg

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -188,11 +188,6 @@ calculate_lancelot_Rt_region <- function(pars, state, transform,
   R <- state[index_R, , , drop = FALSE]
   prob_strain <- state[index_ps, , , drop = FALSE]
 
-  pars_model <- lapply(seq_len(length(info)), function(j)
-    lapply(seq_rows(pars), function(i)
-      transform(pars[i, ])[[j]]$pars))
-
-  pars_model[[1]]$steps_per_day
   dates <- step / 4
 
   n_pars <- nrow(pars)
@@ -224,9 +219,12 @@ calculate_lancelot_Rt_region <- function(pars, state, transform,
       next
     }
 
-    n_strains <- pars_model[[i]][[1]]$n_strains
-    n_strains_R <- pars_model[[i]][[1]]$n_strains_R
-    n_vacc_classes <- pars_model[[i]][[1]]$n_vacc_classes
+    pars_model <- lapply(seq_rows(pars), function(j)
+      transform(pars[j, ])[[i]]$pars)
+
+    n_strains <- pars_model[[1]]$n_strains
+    n_strains_R <- pars_model[[1]]$n_strains_R
+    n_vacc_classes <- pars_model[[1]]$n_vacc_classes
 
     suffix <- paste0("_", c(sircovid:::sircovid_age_bins()$start, "CHW", "CHR"))
     S_nms <- get_names("S", list(n_vacc_classes), suffix)
@@ -246,7 +244,7 @@ calculate_lancelot_Rt_region <- function(pars, state, transform,
     }
 
     rt1 <- sircovid::lancelot_Rt_trajectories(
-      step1, S1, pars_model[[i]], type = type,
+      step1, S1, pars_model, type = type,
       initial_step_from_parameters = initial_step_from_parameters,
       shared_parameters = FALSE, R = R1, prob_strain = prob_strain1,
       weight_Rt = weight_Rt, keep_strains_Rt = keep_strains_Rt)

--- a/R/fit_process.R
+++ b/R/fit_process.R
@@ -731,7 +731,7 @@ calculate_negatives_region <- function(state, pars_model, date) {
   neg <-
     vapply(pillar2_age_bands, calc_negs, array(0, dim = dim(state)[c(2, 3)]))
   neg <- aperm(neg, c(3, 1, 2))
-  rownames(neg) <- paste0("pillar2_negs", pillar2_age_bands)
+  rownames(neg) <- pillar2_age_bands
 
   agg_age_bands <- function(x, name) {
     agg <- apply(x, c(2, 3), sum)
@@ -741,9 +741,10 @@ calculate_negatives_region <- function(state, pars_model, date) {
   }
 
   ## Calculate the negatives for aggregated age bands
-  neg <- abind1(neg, agg_age_bands(neg[pillar2_age_bands, , ], "pillar2_negs"))
+  neg <- abind1(neg, agg_age_bands(neg[pillar2_age_bands, , ], ""))
   neg <-
-    abind1(neg, agg_age_bands(neg[over25_age_bands, , ], "pillar2_negs_over25"))
+    abind1(neg, agg_age_bands(neg[over25_age_bands, , ], "_over25"))
+  rownames(neg) <- paste0("pillar2_negs", rownames(neg))
 
   neg
 }

--- a/R/plot_combined.R
+++ b/R/plot_combined.R
@@ -996,11 +996,21 @@ spim_plot_pillar2_positivity_region <- function(region, dat, age_band,
     x <- x[!predicted]
   }
 
+  model_params <- sample$predict$transform(sample$pars[1, ])
+  model_params <- model_params[[length(model_params)]]$pars
+
   if (age_band == "all") {
-    res <- trajectories["pillar2_positivity", , ]
+    res_pos <- trajectories["sympt_cases_inc", , ]
+    res_neg <- trajectories["pillar2_negs", , ]
   } else {
-    res <- trajectories[paste0("pillar2_positivity_", age_band), , ]
+    res_pos <- trajectories[paste0("sympt_cases_", age_band, "_inc"), , ]
+    res_neg <- trajectories[paste0("pillar2_negs_", age_band), , ]
   }
+
+  res <-
+    (res_pos * model_params$pillar2_sensitivity +
+       res_neg * (1 - model_params$pillar2_specificity)) /
+    (res_pos + res_neg) * 100
 
   ps <- seq(0.025, 0.975, 0.005)
   qs <- apply(res,  MARGIN = 2, FUN = quantile, ps, na.rm = TRUE)


### PR DESCRIPTION
Negatives are stored in the fits instead of positivity, which is then calculated in the plots. This makes combined tasks much quicker. Also speeds up Rt calculation (particularly for multiregion)