### PR TITLE
Control for Rt and forest plot working for multiregion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spimalot
 Title: Support for 'sircovid'
-Version: 0.8.15
+Version: 0.8.16
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",
@@ -74,7 +74,7 @@ Imports:
     patchwork,
     readxl,
     reshape2,
-    sircovid (>= 0.14.7),
+    sircovid (>= 0.14.8),
     stringr,
     tdigest,
     tibble,

--- a/R/combined.R
+++ b/R/combined.R
@@ -62,7 +62,9 @@ spim_combined_load <- function(path, regions = "all", get_severity = FALSE,
   ## reorder by increasing cumulative incidence:
   rank_cum_inc <- lapply(ret$samples, sircovid::get_sample_rank)
   ret$samples <- Map(sircovid::reorder_sample, ret$samples, rank_cum_inc)
-  ret$rt <- Map(reorder_variant_rt, ret$rt, rank_cum_inc, weighted = TRUE)
+  if (!is.null(ret$rt[[1]])) {
+    ret$rt <- Map(reorder_variant_rt, ret$rt, rank_cum_inc, weighted = TRUE)
+  }
 
   message("Aggregating England/UK")
   ## Aggregate some of these to get england/uk entries
@@ -71,7 +73,9 @@ spim_combined_load <- function(path, regions = "all", get_severity = FALSE,
   ## as aggregated Rt values are used in onwards simulations
   agg_samples <- combined_aggregate_samples(ret$samples)
   agg_data <- combined_aggregate_data(ret$data)
-  ret$rt <- combined_aggregate_variant_rt(ret$rt, agg_samples, TRUE)
+  if (!is.null(ret$rt[[1]])) {
+    ret$rt <- combined_aggregate_variant_rt(ret$rt, agg_samples, TRUE)
+  }
   ret$model_demography <- combined_aggregate_demography(ret$model_demography)
 
 

--- a/R/combined.R
+++ b/R/combined.R
@@ -171,7 +171,7 @@ spim_combined_load_multiregion <- function(path) {
   ## as aggregated Rt values are used in onwards simulations
   agg_samples <- combined_aggregate_samples(ret$samples)
   agg_data <- combined_aggregate_data(ret$data)
-  if(!is.null(ret$rt)) {
+  if (!is.null(ret$rt)) {
     ret$rt <- combined_aggregate_variant_rt(ret$rt, agg_samples, TRUE)
   }
 

--- a/R/combined.R
+++ b/R/combined.R
@@ -167,7 +167,9 @@ spim_combined_load_multiregion <- function(path) {
   ## as aggregated Rt values are used in onwards simulations
   agg_samples <- combined_aggregate_samples(ret$samples)
   agg_data <- combined_aggregate_data(ret$data)
-  ret$rt <- combined_aggregate_variant_rt(ret$rt, agg_samples, TRUE)
+  if(!is.null(ret$rt)) {
+    ret$rt <- combined_aggregate_variant_rt(ret$rt, agg_samples, TRUE)
+  }
 
   ## Now the onward object has been created, we can safely store the
   ## other aggregated outputs in ret

--- a/R/control.R
+++ b/R/control.R
@@ -16,6 +16,9 @@
 ##'   regions at once (in which case even the deterministic model may
 ##'   benefit from multithreading).
 ##'
+##' @param rt Logical, indicating if we are calculating Rt trajectories or
+##'   not. Default is TRUE
+##'
 ##' @param severity Logical, indicating if we are outputting severity
 ##'   trajectories (e.g. IFR, IHR, HFR). Default to FALSE.
 ##'
@@ -64,7 +67,7 @@
 ##' @return A list of options
 ##' @export
 spim_control <- function(short_run, n_chains, deterministic = FALSE,
-                         multiregion = FALSE, severity = FALSE,
+                         multiregion = FALSE, rt = TRUE, severity = FALSE,
                          simulate = FALSE, demography = FALSE,
                          date_restart = NULL, n_particles = 192, n_mcmc = 1500,
                          burnin = 500, workers = TRUE, n_sample = 1000,
@@ -121,6 +124,7 @@ spim_control <- function(short_run, n_chains, deterministic = FALSE,
                           n_threads = n_threads,
                           seed = NULL,
                           compiled_compare = compiled_compare,
+                          rt = rt,
                           severity = severity,
                           simulate = simulate,
                           demography = demography)

--- a/R/fit.R
+++ b/R/fit.R
@@ -72,6 +72,7 @@ spim_particle_filter <- function(data, pars, control,
   }
 
   ## Logical flags for the index function
+  rt <- control$rt
   severity <- control$severity
   protected <- control$severity
   cum_infections_disag <- control$simulate
@@ -83,7 +84,7 @@ spim_particle_filter <- function(data, pars, control,
     mcstate::particle_deterministic$new(
       data = data, model = sircovid::lancelot, compare = compare,
       index = function(info)
-        sircovid::lancelot_index(info, severity = severity,
+        sircovid::lancelot_index(info, rt = rt, severity = severity,
                                  protected = protected,
                                  D_all = D_all, D_hosp = D_hosp,
                                  diagnoses_admitted = diagnoses_admitted,
@@ -95,7 +96,7 @@ spim_particle_filter <- function(data, pars, control,
       data = data, model = sircovid::lancelot,
       n_particles = control$n_particles,
       compare = compare, index = function(info)
-        sircovid::lancelot_index(info, severity = severity,
+        sircovid::lancelot_index(info, rt = rt, severity = severity,
                                  protected = protected,
                                  D_all = D_all, D_hosp = D_hosp,
                                  diagnoses_admitted = diagnoses_admitted,

--- a/R/fit_restart.R
+++ b/R/fit_restart.R
@@ -167,7 +167,9 @@ spim_restart_join_parent <- function(fit, parent) {
     ret
   }
 
-  fit$rt <- join_rt(parent$rt, fit$rt, i)
+  if (!is.null(fit$rt) && !is.null(parent$rt)) {
+    fit$rt <- join_rt(parent$rt, fit$rt, i)
+  }
   ## NOTE: Previously we've saved ifr here too, but that needs
   ## reworking for the multistage fits still
 

--- a/R/plot_combined.R
+++ b/R/plot_combined.R
@@ -109,9 +109,11 @@ spim_plot_Rt <- function(dat, regions, rt_type, forecast_until = NULL,
     variant <- "weighted"
   }
   for (r in regions) {
-    if (!is.null(dat$rt[[r]]))
-    spim_plot_Rt_region(r, dat, rt_type, forecast_until, variant, add_betas,
-                        multistrain)
+    ## Only plot if we have calculated Rt - otherwise an empty plot is produced
+    if (!is.null(dat$rt[[r]])) {
+      spim_plot_Rt_region(r, dat, rt_type, forecast_until, variant, add_betas,
+                          multistrain)
+    }
   }
 }
 

--- a/R/plot_combined.R
+++ b/R/plot_combined.R
@@ -109,6 +109,7 @@ spim_plot_Rt <- function(dat, regions, rt_type, forecast_until = NULL,
     variant <- "weighted"
   }
   for (r in regions) {
+    if (!is.null(dat$rt[[r]]))
     spim_plot_Rt_region(r, dat, rt_type, forecast_until, variant, add_betas,
                         multistrain)
   }

--- a/R/plot_combined_forest.R
+++ b/R/plot_combined_forest.R
@@ -129,6 +129,13 @@ spim_plot_forest <- function(dat, regions = NULL, plot_type = "all",
       jitter <- 0.5
       regions <- names(par)
       hp <- subset(hps, hps$name == par_name)
+      if (is.na(hp$region[1])) {
+        hp <- hp[rep(1, length(regions)), ]
+        hp$region <- regions
+        col <- "red"
+      } else {
+        col <- "grey20"
+      }
       rownames(hp) <- hp$region
       hp <- hp[regions, ] # sort in correct order
       if (hp$type[1] == "beta") {
@@ -168,7 +175,8 @@ spim_plot_forest <- function(dat, regions = NULL, plot_type = "all",
                  col = col_line, lty = 2, lwd = 1, lend = 2)
       }
 
-      mapply(FUN = plot_ci_bar, res = par, at = at, width = 0.1)
+      mapply(FUN = plot_ci_bar, res = par, at = at, width = 0.1,
+             col = col)
     }
   }
 

--- a/man/spim_control.Rd
+++ b/man/spim_control.Rd
@@ -9,6 +9,7 @@ spim_control(
   n_chains,
   deterministic = FALSE,
   multiregion = FALSE,
+  rt = TRUE,
   severity = FALSE,
   simulate = FALSE,
   demography = FALSE,
@@ -37,6 +38,9 @@ data is run deterministically or stochastically}
 \item{multiregion}{Logical, indicating if we are fitting multiple
 regions at once (in which case even the deterministic model may
 benefit from multithreading).}
+
+\item{rt}{Logical, indicating if we are calculating Rt trajectories or
+not. Default is TRUE}
 
 \item{severity}{Logical, indicating if we are outputting severity
 trajectories (e.g. IFR, IHR, HFR). Default to FALSE.}


### PR DESCRIPTION
Adds control so we can choose whether or not to calculate RT. Also tweaks the forest plot function to allow it to run with multiregion parameters. Requires https://github.com/mrc-ide/sircovid/pull/432